### PR TITLE
Enable ScramSHA1 auth provider

### DIFF
--- a/lib/Database.js
+++ b/lib/Database.js
@@ -9,6 +9,7 @@ import Cursor from './Cursor';
 const Server = mongodb.Server;
 const ReplSet = mongodb.ReplSet;
 const MongoCR = mongodb.MongoCR;
+const ScramSHA1 = mongodb.ScramSHA1
 
 export default class Database {
   constructor(connectionString, options, collections) {
@@ -112,9 +113,11 @@ export default class Database {
 
         if (config.auth) {
           server.addAuthProvider('mongocr', new MongoCR());
+          server.addAuthProvider('ScramSHA1', new ScramSHA1());
           // authenticate on connect
           server.on('connect', function (server) {
-            server.auth('mongocr', config.dbName, config.auth.user, config.auth.password,
+            const providerName = options.authMechanism ? options.authMechanism : 'mongocr';
+            server.auth(providerName, config.dbName, config.auth.user, config.auth.password,
               function (error, server) {
                 if (error) {
                   reject(error);


### PR DESCRIPTION
Credits to @tjyrkinen

Enables ScramSHA1 for Mongo 3.

When creating the connection:
`pmongo(connString, {
        authMechanism: 'ScramSHA1'
    }, collections);`
